### PR TITLE
Restore GeoIP files

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@ package manager by setting `GRANAX_USE_SYSTEM_TOR=1`.
 You can also tell Granax to install the latest alpha release of Tor instead of 
 the latest stable release, with `GRANAX_USE_TOR_ALPHA=1`.
 
+Tor requires Geo IP files for by-country configurations (e.g.`EntryNodes {us}`).
+These files weight ~8mb, if you don't need them, you may choose to remove them by
+setting `GRANAX_REMOVE_GEOIP=1`.
+
 ```js
 const tor = require('@deadcanaries/granax')();
 

--- a/index.js
+++ b/index.js
@@ -13,6 +13,7 @@ const { Socket } = require('net');
 const { readFileSync } = require('fs');
 
 const BIN_PATH = path.join(__dirname, 'bin');
+const TOR_DIRECTORY_PATH = path.join(BIN_PATH, 'Tor');
 const LD_LIBRARY_PATH = path.join(
   BIN_PATH, 'tor-browser_en-US', 'Browser', 'TorBrowser', 'Tor'
 );
@@ -31,8 +32,8 @@ module.exports = function(options, torrcOptions) {
   let [torrc, datadir] = module.exports.torrc(torrcOptions);
 
   let exe = path.basename(module.exports.tor(platform()));
-  let tor = path.join(BIN_PATH, 'Tor', exe);
-  let env = { LD_LIBRARY_PATH: path.join(BIN_PATH, 'Tor') };
+  let tor = path.join(TOR_DIRECTORY_PATH, exe);
+  let env = { LD_LIBRARY_PATH: TOR_DIRECTORY_PATH };
 
   if (process.env.GRANAX_USE_SYSTEM_TOR && process.platform === 'linux') {
     tor = exe;
@@ -86,6 +87,11 @@ module.exports = function(options, torrcOptions) {
 };
 
 /**
+ * @type {string}
+ */
+module.exports.TOR_DIRECTORY_PATH = TOR_DIRECTORY_PATH;
+
+/**
  * Returns the local path to the tor bundle
  * @returns {string}
  */
@@ -125,6 +131,30 @@ module.exports.tor = function(platform) {
   }
 
   return torpath;
+};
+
+/**
+ * Returns the local path to the Geo IP file
+ * @param {('IPv4'|'IPv6')} [protocol='IPv4'] - IP protocol version
+ * @returns {string}
+ */
+module.exports.getGeoIpPath = function(platform, protocol = 'IPv4') {
+  const filename = `geoip${protocol === 'IPv6' ? '6' : ''}`;
+
+  switch (platform) {
+    case 'win32':
+      return path.join(BIN_PATH, 'Browser', 'TorBrowser', 'Data', 'Tor',
+        filename);
+    case 'darwin':
+      return path.join(BIN_PATH, '.tbb.app', 'Contents', 'Resources',
+        'TorBrowser', 'Tor', filename);
+    case 'android':
+    case 'linux':
+      return path.join(BIN_PATH, 'tor-browser_en-US', 'Browser', 'TorBrowser',
+        'Data', 'Tor', filename);
+    default:
+      throw new Error(`Unsupported platform "${platform}"`);
+  }
 };
 
 /**

--- a/index.js
+++ b/index.js
@@ -134,12 +134,21 @@ module.exports.tor = function(platform) {
 };
 
 /**
+ * Returns the Geo IP filename
+ * @param {('IPv4'|'IPv6')} [protocol='IPv4'] - IP protocol version
+ * @returns {string}
+ */
+module.exports.getGeoIpFilename = function(protocol = 'IPv4') {
+  return `geoip${protocol === 'IPv6' ? '6' : ''}`;
+};
+
+/**
  * Returns the local path to the Geo IP file
  * @param {('IPv4'|'IPv6')} [protocol='IPv4'] - IP protocol version
  * @returns {string}
  */
 module.exports.getGeoIpPath = function(platform, protocol = 'IPv4') {
-  const filename = `geoip${protocol === 'IPv6' ? '6' : ''}`;
+  const filename = module.exports.getGeoIpFilename(protocol);
 
   switch (platform) {
     case 'win32':

--- a/lib/torrc.js
+++ b/lib/torrc.js
@@ -8,7 +8,8 @@ const path = require('path');
 const mkdirp = require('mkdirp');
 const { randomBytes } = require('crypto');
 const { tmpdir } = require('os');
-const { writeFileSync } = require('fs');
+const { writeFileSync, existsSync } = require('fs');
+const { TOR_DIRECTORY_PATH, getGeoIpFilename } = require('..');
 
 
 /**
@@ -29,6 +30,15 @@ module.exports = function(options = {}) {
     'ControlPort auto',
     'CookieAuthentication 1'
   ];
+
+  ['IPv4', 'IPv6'].forEach((protocol) => {
+    const geoIpPath = path.join(TOR_DIRECTORY_PATH, getGeoIpFilename(protocol));
+    if (existsSync(geoIpPath)) {
+      torrcContent.push(
+        `${protocol === 'IPv4' ? 'GeoIPFile' : 'GeoIPv6File'} ${geoIpPath}`
+      );
+    }
+  });
 
   if (!Array.isArray(options)) {
     options = [options];

--- a/test/index.unit.js
+++ b/test/index.unit.js
@@ -4,7 +4,7 @@ const { expect } = require('chai');
 const proxyquire = require('proxyquire');
 const sinon = require('sinon');
 const { EventEmitter } = require('events');
-const { TorController } = require('..');
+const { TorController, getGeoIpPath } = require('..');
 
 
 describe('@module granax', function() {
@@ -101,6 +101,27 @@ describe('@module granax', function() {
     });
 
     it('should throw if unsupported platform', function() {
+
+    });
+
+  });
+
+  describe('@function getGeoIpPath', function() {
+
+    ['IPv4', 'IPv6'].forEach((protocol) => {
+
+      ['win32', 'darwin', 'linux', 'android'].forEach((platform) => {
+        it(`should return the ${platform} ${protocol} path`, function() {
+          expect(getGeoIpPath(platform, protocol))
+            .to.be.a('string').that.is.not.empty;
+        });
+      });
+
+      it('should throw if unsupported platform', function() {
+        expect(function() {
+          getGeoIpPath('colossus');
+        }).to.throw(Error, 'Unsupported platform "colossus"');
+      });
 
     });
 

--- a/test/torrc.unit.js
+++ b/test/torrc.unit.js
@@ -7,25 +7,51 @@ const sinon = require('sinon');
 
 describe('@module granax/torrc', function() {
 
+  const sandbox = sinon.sandbox.create();
+  const _mkdirpSync = sandbox.stub();
+  const _writeFileSync = sandbox.stub();
+  const _existsSync = sandbox.stub();
+  const torrc = proxyquire('../lib/torrc', {
+    mkdirp: {
+      sync: _mkdirpSync
+    },
+    fs: {
+      writeFileSync: _writeFileSync,
+      existsSync: _existsSync
+    }
+  });
+
+  afterEach(() => sandbox.reset());
+
   describe('@exports', function() {
 
     it('should write the torrc to tmp', function() {
-      const _mkdirpSync = sinon.stub();
-      const _writeFileSync = sinon.stub();
-      const torrc = proxyquire('../lib/torrc', {
-        mkdirp: {
-          sync: _mkdirpSync
-        },
-        fs: {
-          writeFileSync: _writeFileSync
-        }
-      });
       const result = torrc();
       expect(_mkdirpSync.called).to.equal(true);
       expect(_writeFileSync.called).to.equal(true);
       expect(typeof result[0]).to.equal('string');
       expect(typeof result[1]).to.equal('string');
       expect(Array.isArray(result)).to.equal(true);
+    });
+
+    it('should add Geo IP files path to the torrc', function() {
+      _existsSync.returns(true);
+      torrc();
+      expect(_existsSync.calledTwice).to.equal(true);
+      expect(_writeFileSync.calledWith(
+        sinon.match.string,
+        sinon.match(/GeoIPFile/).and(sinon.match(/GeoIPv6File/))
+      )).to.equal(true);
+    });
+
+    it('should not add Geo IP files path to the torrc', function() {
+      _existsSync.returns(false);
+      torrc();
+      expect(_existsSync.calledTwice).to.equal(true);
+      expect(_writeFileSync.calledWith(
+        sinon.match.string,
+        sinon.match(/GeoIPFile/).or(sinon.match(/GeoIPv6File/))
+      )).to.equal(false);
     });
 
   });


### PR DESCRIPTION
Hi @emeryrose,

First of all, thank you for all your work on this project.

Tor `by-country` configurations (e.g.`EntryNodes {us}`) require Geo IP files to be defined in torrc. These files are packaged with TBB but are now removed by the cleanup TBB implementation (3ededbf).

The purpose of this PR is to move them alongside the Tor executable into the Tor directory unless the env variable `GRANAX_REMOVE_GEOIP=1` is set. Torrc.js is also updated to add their configurations within generated torrc files if they exist.

Feel free to make any comments or suggestions, I'm glad to make changes.
